### PR TITLE
Add Gradle support while keeping Ant support.

### DIFF
--- a/dependencies/gpgex/build.gradle
+++ b/dependencies/gpgex/build.gradle
@@ -1,0 +1,29 @@
+buildscript {
+	repositories {
+		maven {
+			url "http://repo1.maven.org/maven2/"
+		}
+	}
+	dependencies {
+		classpath 'com.android.tools.build:gradle:2.1.0'
+	}
+}
+
+apply plugin: 'com.android.library'
+
+android {
+	sourceSets {
+		main {
+			manifest.srcFile 'AndroidManifest.xml'
+			java.srcDirs = ['src']
+			res.srcDirs = ['res']
+		}
+	}
+	compileSdkVersion Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
+	buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
+}
+
+dependencies {
+	compile project(':deps:extension-api')
+	compile project(':deps:google-play-services')
+}

--- a/haxelib.json
+++ b/haxelib.json
@@ -6,8 +6,9 @@
         "tags": ["social","api","google-play-games","gpg","googleplaygames","games","openfl"],
         "description": "OpenFL Google Play Games extension for Android.",
         "dependencies": {
-            "extension-googleplayservices-basement": ""
+            "extension-googleplayservices-basement": "",
+			"google-play-services": ""
         },
-        "version": "1.5.0",
-        "releasenote": "Upgrade to extension-googleplayservices-basement."
+        "version": "1.5.1",
+        "releasenote": "Add Gradle support."
 }

--- a/include.xml
+++ b/include.xml
@@ -1,12 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension>
 	<section if="android">
-		<set name="google-play-services-basement" />
-		<set name="google-play-services-games" />
-		<set name="google-play-services-base" />
-		<set name="google-play-services-plus" />
-		<set name="google-play-services-drive" />
-		<haxelib name="extension-googleplayservices-basement" /> 
+		<section unless="openfl-legacy || openfl-next">
+			<set name="google-play-game-services" />
+			<set name="google-plus" />
+			<set name="google-drive" />
+			<haxelib name="google-play-services" />
+		</section>
+		
+		<section if="openfl-legacy || openfl-next">
+			<set name="google-play-services-basement" />
+			<set name="google-play-services-games" />
+			<set name="google-play-services-base" />
+			<set name="google-play-services-plus" />
+			<set name="google-play-services-drive" />
+			<haxelib name="extension-googleplayservices-basement" /> 
+		</section>
+		
 		<dependency name="gpgex" path="dependencies/gpgex" /> 
 	</section>
 </extension>


### PR DESCRIPTION
Based on [this commit](https://github.com/SempaiGames/extension-amazon-sns/commit/0fe9bc3c19d223820e5493910bb7b3840f10614a).

For consistency, I used hyphen-separated names instead of camelCase ones. This was always an option, but I'd forgotten about it until now.