### PR TITLE
callback for onGetPlayerImageError, try/catch failure dialog, manifest merging

### DIFF
--- a/dependencies/gpgex/AndroidManifest.xml
+++ b/dependencies/gpgex/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.gpgex">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-sdk android:minSdkVersion="::ANDROID_MINIMUM_SDK_VERSION::" android:targetSdkVersion="::ANDROID_TARGET_SDK_VERSION::" />
     <application android:debuggable="::DEBUG::">
         <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
         <meta-data android:name="com.google.android.gms.games.APP_ID" android:value="@string/APP_ID" />

--- a/dependencies/gpgex/project.properties
+++ b/dependencies/gpgex/project.properties
@@ -1,4 +1,5 @@
 android.library=true
+manifestmerger.enabled = true
 target=android-::ANDROID_TARGET_SDK_VERSION::
 android.library.reference.1=../extension-api
 android.library.reference.2=../google-play-services-basement

--- a/dependencies/gpgex/src/com/gpgex/GameHelper.java
+++ b/dependencies/gpgex/src/com/gpgex/GameHelper.java
@@ -136,7 +136,7 @@ public class GameHelper implements GoogleApiClient.ConnectionCallbacks,
     SignInFailureReason mSignInFailureReason = null;
 
     // Should we show error dialog boxes?
-    boolean mShowErrorDialogs = true;
+    boolean mShowErrorDialogs = false;
 
     // Print debug logs?
     boolean mDebugLog = false;
@@ -809,16 +809,21 @@ public class GameHelper implements GoogleApiClient.ConnectionCallbacks,
     }
 
     public void showFailureDialog() {
-        if (mSignInFailureReason != null) {
-            int errorCode = mSignInFailureReason.getServiceErrorCode();
-            int actResp = mSignInFailureReason.getActivityResultCode();
 
-            if (mShowErrorDialogs) {
-                showFailureDialog(mActivity, actResp, errorCode);
-            } else {
-                debugLog("Not showing error dialog because mShowErrorDialogs==false. " + "" +
-                        "Error was: " + mSignInFailureReason);
+        try {
+            if (mSignInFailureReason != null) {
+                int errorCode = mSignInFailureReason.getServiceErrorCode();
+                int actResp = mSignInFailureReason.getActivityResultCode();
+
+                if (mShowErrorDialogs) {
+                    showFailureDialog(mActivity, actResp, errorCode);
+                } else {
+                    debugLog("Not showing error dialog because mShowErrorDialogs==false. " + "" +
+                            "Error was: " + mSignInFailureReason);
+                }
             }
+        } catch (Exception e) {
+            debugLog("Could not show failure dialog : " + e.getMessage());
         }
     }
 
@@ -830,34 +835,40 @@ public class GameHelper implements GoogleApiClient.ConnectionCallbacks,
         }
         Dialog errorDialog = null;
 
-        switch (actResp) {
-            case GamesActivityResultCodes.RESULT_APP_MISCONFIGURED:
-                errorDialog = makeSimpleDialog(activity, GameHelperUtils.getString(activity,
-                        GameHelperUtils.R_APP_MISCONFIGURED));
-                break;
-            case GamesActivityResultCodes.RESULT_SIGN_IN_FAILED:
-                errorDialog = makeSimpleDialog(activity, GameHelperUtils.getString(activity,
-                        GameHelperUtils.R_SIGN_IN_FAILED));
-                break;
-            case GamesActivityResultCodes.RESULT_LICENSE_FAILED:
-                errorDialog = makeSimpleDialog(activity, GameHelperUtils.getString(activity,
-                        GameHelperUtils.R_LICENSE_FAILED));
-                break;
-            default:
-                // No meaningful Activity response code, so generate default Google
-                // Play services dialog
-                errorDialog = GooglePlayServicesUtil.getErrorDialog(errorCode, activity,
-                        RC_UNUSED, null);
-                if (errorDialog == null) {
-                    // get fallback dialog
-                    Log.e("GameHelper", "No standard error dialog available. Making fallback dialog.");
-                    errorDialog = makeSimpleDialog(activity,
-                            GameHelperUtils.getString(activity, GameHelperUtils.R_UNKNOWN_ERROR)
-                            + " " + GameHelperUtils.errorCodeToString(errorCode));
-                }
-        }
+        try {
 
-        errorDialog.show();
+            switch (actResp) {
+                case GamesActivityResultCodes.RESULT_APP_MISCONFIGURED:
+                    errorDialog = makeSimpleDialog(activity, GameHelperUtils.getString(activity,
+                            GameHelperUtils.R_APP_MISCONFIGURED));
+                    break;
+                case GamesActivityResultCodes.RESULT_SIGN_IN_FAILED:
+                    errorDialog = makeSimpleDialog(activity, GameHelperUtils.getString(activity,
+                            GameHelperUtils.R_SIGN_IN_FAILED));
+                    break;
+                case GamesActivityResultCodes.RESULT_LICENSE_FAILED:
+                    errorDialog = makeSimpleDialog(activity, GameHelperUtils.getString(activity,
+                            GameHelperUtils.R_LICENSE_FAILED));
+                    break;
+                default:
+                    // No meaningful Activity response code, so generate default Google
+                    // Play services dialog
+                    errorDialog = GooglePlayServicesUtil.getErrorDialog(errorCode, activity,
+                            RC_UNUSED, null);
+                    if (errorDialog == null) {
+                        // get fallback dialog
+                        Log.e("GameHelper", "No standard error dialog available. Making fallback dialog.");
+                        errorDialog = makeSimpleDialog(activity,
+                                GameHelperUtils.getString(activity, GameHelperUtils.R_UNKNOWN_ERROR)
+                                + " " + GameHelperUtils.errorCodeToString(errorCode));
+                    }
+            }
+
+            errorDialog.show();
+
+        } catch (Exception e) {
+            Log.e("GameHelper", "*** Could not show failure dialog : " + e.getMessage());
+        }
     }
 
     static Dialog makeSimpleDialog(Activity activity, String text) {

--- a/dependencies/gpgex/src/com/gpgex/GooglePlayGames.java
+++ b/dependencies/gpgex/src/com/gpgex/GooglePlayGames.java
@@ -298,6 +298,7 @@ public class GooglePlayGames extends Extension implements GameHelper.GameHelperL
 				}catch(Exception e) {
 					Log.i(TAG, "PlayGames: getPlayerImage Exception");
 					Log.i(TAG, e.toString());
+					callbackObject.call1("onGetPlayerImageError", e.toString());
 				}
 			}
 		});
@@ -331,6 +332,7 @@ public class GooglePlayGames extends Extension implements GameHelper.GameHelperL
 					Log.i(TAG, "PlayGames: getPlayerImage  exception trying to save: ");
 					Log.i(TAG, e.toString());
 						//TODO: Handle exception
+					callbackObject.call1("onGetPlayerImageError", e.toString());
 				}
 			}
 		}, uri);

--- a/extension/gpg/GooglePlayGames.hx
+++ b/extension/gpg/GooglePlayGames.hx
@@ -152,6 +152,7 @@ class GooglePlayGames {
 	public static var onLoadConnectedPlayers : Array<Player>->Void = null;
 	public static var onLoadInvitablePlayers : Array<Player>->Void = null;
 	public static var onLoadPlayerImage : String->String->Void = null;
+	public static var onLoadPlayerImageError : String->Void = null;
 	public static var onGetPlayerCurrentSteps : String->Int->Void = null;
 
 	private static var initted:Bool=false;
@@ -242,6 +243,10 @@ class GooglePlayGames {
 
 	public function onGetPlayerImage(id:String, path:String) {
 		if(onLoadPlayerImage!=null) Timer.delay(function(){ onLoadPlayerImage(id, path); },0);
+	}
+
+	public function onGetPlayerImageError(e:String) {
+		if(onLoadPlayerImageError!=null) Timer.delay(function(){ onLoadPlayerImageError(e); },0);
 	}
 	
 }


### PR DESCRIPTION
- Added callback for onGetPlayerImageError - so you don't have to keep waiting for it in haxe
- try/catch for failure dialog ( fails on some devices for some reason )
- manifest merging + target sdk versions